### PR TITLE
Grant network permission for library manager

### DIFF
--- a/cc.arduino.arduinoide.json
+++ b/cc.arduino.arduinoide.json
@@ -17,6 +17,7 @@
     "finish-args": [
         "--socket=x11",
         "--share=ipc",
+        "--share=network",
         "--device=all",
         "--filesystem=home"
     ],


### PR DESCRIPTION
The built-in library manager needs network access to fetch the package list and the packages itself.