### PR TITLE
Bump to 1.8.11

### DIFF
--- a/arduino-appdata-fixes.patch
+++ b/arduino-appdata-fixes.patch
@@ -1,29 +1,11 @@
-diff --git a/build/linux/dist/appdata.xml b/build/linux/dist/appdata.xml
-index dc0c5937d..d55870627 100644
 --- a/build/linux/dist/appdata.xml
 +++ b/build/linux/dist/appdata.xml
-@@ -3,6 +3,7 @@
- <component type="desktop-application">
-   <id>cc.arduino.arduinoide.desktop</id>
-   <metadata_license>CC-BY-SA-3.0</metadata_license>
-+  <project_license>LGPL-2.1</project_license>
-   <developer_name>Arduino LLC</developer_name>
+@@ -38,7 +38,8 @@
+   <content_rating type="oars-1.1" />
  
-   <name>Arduino IDE</name>
-@@ -32,6 +33,16 @@
-     </screenshot>
-   </screenshots>
- 
-+  <content_rating type="oars-1.1" />
-+
-+  <releases>
-+    <release date="2017-10-02" version="1.8.5"/>
-+    <release date="2017-08-21" version="1.8.4"/>
-+    <release date="2017-06-05" version="1.8.3"/>
-+    <release date="2017-03-22" version="1.8.2"/>
-+    <release date="2017-01-09" version="1.8.1"/>
-+  </releases>
-+
-   <url type="homepage">http://www.arduino.cc/</url>
-   <url type="help">https://www.arduino.cc/en/Guide/HomePage</url>
-   <url type="bugtracker">https://github.com/arduino/Arduino/issues</url>
+   <releases>
++    <release date="2020-01-27" version="1.8.11"/>
+     <release date="2019-09-13" version="1.8.10"/>
+     <release date="2019-03-15" version="1.8.9"/>
+     <release date="2018-12-06" version="1.8.8"/>
+     <release date="2018-09-11" version="1.8.7"/>

--- a/cc.arduino.arduinoide.json
+++ b/cc.arduino.arduinoide.json
@@ -1,10 +1,10 @@
 {
     "app-id": "cc.arduino.arduinoide",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "18.08",
+    "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk10"
+        "org.freedesktop.Sdk.Extension.openjdk11"
     ],
     "rename-icon": "arduino",
     "build-options": {
@@ -33,7 +33,7 @@
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk10/install.sh"
+                "/usr/lib/sdk/openjdk11/install.sh"
             ]
         },
         {
@@ -41,8 +41,8 @@
             "buildsystem": "simple",
             "build-options": {
                 "env": {
-                    "PATH": "/usr/bin:/usr/lib/sdk/openjdk10/jvm/openjdk-10/bin",
-                    "JAVA_HOME": "/usr/lib/sdk/openjdk10/jvm/openjdk-10"
+                    "PATH": "/usr/bin:/usr/lib/sdk/openjdk11/jvm/openjdk-11/bin",
+                    "JAVA_HOME": "/usr/lib/sdk/openjdk11/jvm/openjdk-11"
                 }
             },
             "build-commands": [
@@ -62,8 +62,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/arduino/Arduino/releases/download/1.8.5/Arduino-1.8.5.tar.xz",
-                    "sha256": "f4c98433d65e78ab01ec8efa64a0fc66dc5877d96eaf89733f965b1f9246ee32"
+                    "url": "https://github.com/arduino/Arduino/releases/download/1.8.11/arduino-1.8.11.tar.xz",
+                    "sha256": "969ef35bd8390a06783a34ae20e9829e1660f20e7e0a1a42037f4b86deb64ea9"
                 },
                 {
                     "type": "patch",
@@ -89,17 +89,59 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/arduino-libraries/Firmata/archive/2.5.6.zip",
-                    "sha256": "64bac00238ae71dfa1795f6f84c36b2026849d9c4cd447db03663fda2e69ed84",
-                    "dest": "build",
-                    "dest-filename": "Firmata-2.5.6.zip"
+                    "url": "https://downloads.arduino.cc/cores/avr-1.8.2.tar.bz2",
+                    "sha256": "6213d41c6e91a75ac931527da5b10f2dbe0140c8cc1dd41b06cd4e78b943f41b",
+                    "dest": "build"
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/arduino-libraries/Bridge/archive/1.6.3.zip",
-                    "sha256": "b2d652f70dd44a6cbebfcc3b470f51dc27a85fcda4c3752c7b6b98ff272f0ad2",
+                    "url": "https://github.com/arduino-libraries/Ethernet/archive/2.0.0.zip",
+                    "sha256": "a8a650774a613f6eaeae49e2b32f003e42b65be4adc479944b9d071b98214d41",
                     "dest": "build",
-                    "dest-filename": "Bridge-1.6.3.zip"
+                    "dest-filename": "Ethernet-2.0.0.zip"
+                    
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/arduino-libraries/GSM/archive/1.0.6.zip",
+                    "sha256": "737187d301a6d6eade181488106d3826f6466a926f570fa1d5dfb303729fb1ce",
+                    "dest": "build",
+                    "dest-filename": "GSM-1.0.6.zip"
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/arduino-libraries/Stepper/archive/1.1.3.zip",
+                    "sha256": "9bdc308d1b4a0bafde01123c80aa25458bc6bd22609fd3d13f50ae0aeb32dbcf",
+                    "dest": "build",
+                    "dest-filename": "Stepper-1.1.3.zip"
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/arduino-libraries/TFT/archive/1.0.6.zip",
+                    "sha256": "bcc8e2a0ec6add55ca13ccca801331c3c090f3d4c46fd0b34545ed0cc7edc9b4",
+                    "dest": "build",
+                    "dest-filename": "TFT-1.0.6.zip"
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/arduino-libraries/WiFi/archive/1.2.7.zip",
+                    "sha256": "c61d68237742a39b7d5843496749e123c6721083bd002bcbdd118a630416b2ba",
+                    "dest": "build",
+                    "dest-filename": "WiFi-1.2.7.zip"
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/firmata/arduino/archive/2.5.8.zip",
+                    "sha256": "429cdb6f0a4c6b8cadb2d3a3ecb6a50cb083833454332827f67abac26dc6b44a",
+                    "dest": "build",
+                    "dest-filename": "Firmata-2.5.8.zip"
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/arduino-libraries/Bridge/archive/1.7.0.zip",
+                    "sha256": "4823cca4e0a60311c0a5bb75a8bced780a99987ccd86f91926559e23ab58f6e2",
+                    "dest": "build",
+                    "dest-filename": "Bridge-1.7.0.zip"
                 },
                 {
                     "type": "file",
@@ -124,10 +166,10 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.1.zip",
-                    "sha256": "20e9d17b08413fc5412fa2549a112b088b92371bcd7450337dcb18fe69f546ff",
+                    "url": "https://github.com/arduino-libraries/SpacebrewYun/archive/1.0.2.zip",
+                    "sha256": "48cf66b677dc1ce03643a6bdd222f9be6d86081c29d6dda870108bd075ad1ab5",
                     "dest": "build",
-                    "dest-filename": "SpacebrewYun-1.0.1.zip"
+                    "dest-filename": "SpacebrewYun-1.0.2.zip"
                 },
                 {
                     "type": "file",
@@ -152,24 +194,24 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/arduino-libraries/Keyboard/archive/1.0.1.zip",
-                    "sha256": "4c69b1b102547c64570ba2a1b3bf5fb4b5353237d0ca7fdf062b2f09ff38fbea",
+                    "url": "https://github.com/arduino-libraries/Keyboard/archive/1.0.2.zip",
+                    "sha256": "a34c261f4746d658647e5632e4bae8641d8055ed354f820f5aeec4904b92ce9f",
                     "dest": "build",
-                    "dest-filename": "Keyboard-1.0.1.zip"
+                    "dest-filename": "Keyboard-1.0.2.zip"
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/arduino-libraries/SD/archive/1.1.1.zip",
-                    "sha256": "f61011d6f6ca4d8cb709c3e48871a516484425cbda722274b8b6747f1c9b4c59",
+                    "url": "https://github.com/arduino-libraries/SD/archive/1.2.4.zip",
+                    "sha256": "df0d17e201600fcdcf2ae9bbd76d2919125d9afc1c73934cd799619bfa4d6f88",
                     "dest": "build",
-                    "dest-filename": "SD-1.1.1.zip"
+                    "dest-filename": "SD-1.2.4.zip"
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/arduino-libraries/Servo/archive/1.1.2.zip",
-                    "sha256": "871e82817a609fbbfc79c3752e87dedb8b81ffd71365502d2f82f48c07426192",
+                    "url": "https://github.com/arduino-libraries/Servo/archive/1.1.6.zip",
+                    "sha256": "43cbb1196566ef5bb139506ef69312d93d5e26710679982072a315f93b4d33fd",
                     "dest": "build",
-                    "dest-filename": "Servo-1.1.2.zip"
+                    "dest-filename": "Servo-1.1.6.zip"
                 },
                 {
                     "type": "file",
@@ -180,83 +222,83 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/1.6.8.zip",
-                    "sha256": "81c832340ace9e1f2c4a09d820dc3db6346cf4209ab2e7c346fd7915fb31a67e",
+                    "url": "https://github.com/Adafruit/Adafruit_CircuitPlayground/archive/1.10.4.zip",
+                    "sha256": "d49a9a1d9f24b753bc17187801b66f7824de32fe809f67c9e340ffde6ff98aa4",
                     "dest": "build",
-                    "dest-filename": "Adafruit_CircuitPlayground-1.6.8.zip"
+                    "dest-filename": "Adafruit_Circuit_Playground-1.10.4.zip"
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.9.1/WiFi101-Updater-ArduinoIDE-Plugin-0.9.1.zip",
-                    "sha256": "e4e09b4cbd45406fe3d2833daa021b113b835523bde1cdaaa2e6b6f0d1fdf996",
+                    "url": "https://github.com/arduino-libraries/WiFi101-FirmwareUpdater-Plugin/releases/download/v0.10.10/WiFi101-Updater-ArduinoIDE-Plugin-0.10.10.zip",
+                    "sha256": "0d70f3aa3cd7dc46cc402fc0a915519e7cf8af6cdc544458c182394d5fc3452f",
                     "dest": "build/shared"
                 },
                 {
                     "type": "file",
-                    "url": "https://downloads.arduino.cc/libastylej-2.05.1-3.zip",
-                    "sha256": "46f54a503edd7dcb698d6b03deb40cf6aa16a468c5ef2072d1b403da98f03d28",
+                    "url": "https://downloads.arduino.cc/libastylej-2.05.1-5.zip",
+                    "sha256": "def22874099c28d482720ee2a444ec4709f0980bae41f3ebb6033bbc79beb486",
                     "dest": "build"
                 },
                 {
                     "type": "file",
-                    "url": "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.0.zip",
-                    "sha256": "dbffa2bfb69e03151345567233392b283717a36ccb4df8ed1fd8ead3fd723589",
-                    "dest": "build"
-                },
-                {
-                    "only-arches": ["arm"],
-                    "type": "file",
-                    "url": "https://downloads.arduino.cc/tools/arduino-builder-linuxarm-1.3.25.tar.bz2",
-                    "sha256": "3e4f2f1a7b00e50988f4c6c68f50b367da0fdbb9bc491ef0d361b7c52e8c74cb",
-                    "dest": "build"
-                },
-                {
-                    "only-arches": ["x86_64"],
-                    "type": "file",
-                    "url": "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.3.25.tar.bz2",
-                    "sha256": "0e632b3326eb5a74dc8363bf88c139ae6a7c21c10db18d047859f052c405c897",
+                    "url": "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2-2.zip",
+                    "sha256": "a338d470822de19bd971bd7a71d43f5273ba082baa9236be28c44b47c3e51f6b",
                     "dest": "build"
                 },
                 {
                     "only-arches": ["arm"],
                     "type": "file",
-                    "url": "https://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-armhf-pc-linux-gnu.tar.bz2",
-                    "sha256": "ee36009e19bd238d1f6351cbc9aa5db69714761f67dec4c1d69d5d5d7758720c",
+                    "url": "https://downloads.arduino.cc/tools/arduino-builder-linuxarm-1.5.1.tar.bz2",
+                    "sha256": "f3d1b5ef469012ef604bdba0c1bdf6d403ca6488555bbfbaf125e8991d6e7ee2",
+                    "dest": "build"
+                },
+                {
+                    "only-arches": ["x86_64"],
+                    "type": "file",
+                    "url": "https://downloads.arduino.cc/tools/arduino-builder-linux64-1.5.1.tar.bz2",
+                    "sha256": "f7cb9f737a34c33e8d825c5152642d3b6f515b3180dcb471373c00283034c00e",
+                    "dest": "build"
+                },
+                {
+                    "only-arches": ["arm"],
+                    "type": "file",
+                    "url": "https://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-arm-linux-gnueabihf.tar.bz2",
+                    "sha256": "f4acd5531c6b82c715e2edfa0aadb13fb718b4095b3ea1aa1f7fbde680069639",
                     "dest": "build/linux"
                 },
                 {
                     "only-arches": ["x86_64"],
                     "type": "file",
-                    "url": "https://downloads.arduino.cc/tools/avr-gcc-4.9.2-atmel3.5.4-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-                    "sha256": "19480217f1524d78467b83cd742f503182bbcc76b5440093261f146828aa588c",
+                    "url": "https://downloads.arduino.cc/tools/avr-gcc-7.3.0-atmel3.6.1-arduino5-x86_64-pc-linux-gnu.tar.bz2",
+                    "sha256": "3effed8ffa1978b6e4a46f1aa2acc629e440b4d77244f71f9b79a916025206fb",
                     "dest": "build/linux"
                 },
                 {
                     "only-arches": ["arm"],
                     "type": "file",
-                    "url": "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-armhf-pc-linux-gnu.tar.bz2",
-                    "sha256": "25a6834ae48019fccf37024236a1f79fe21760414292a4f3fa058d937ceee1ce",
+                    "url": "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-armhf-pc-linux-gnu.tar.bz2",
+                    "sha256": "2a8e68c5d803aa6f902ef219f177ec3a4c28275d85cbe272962ad2cd374f50d1",
                     "dest": "build/linux"
                 },
                 {
                     "only-arches": ["x86_64"],
                     "type": "file",
-                    "url": "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino9-x86_64-pc-linux-gnu.tar.bz2",
-                    "sha256": "c8cccb84e2fe49ee837b24f0a60a99e9c371dae26e84c5b0b22b6b6aab2f1f6a",
+                    "url": "https://downloads.arduino.cc/tools/avrdude-6.3.0-arduino17-x86_64-pc-linux-gnu.tar.bz2",
+                    "sha256": "accdfb920af2aabf4f7461d2ac73c0751760f525216dc4e7657427a78c60d13d",
                     "dest": "build/linux"
                 },
                 {
                     "only-arches": ["arm"],
                     "type": "file",
-                    "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.1.1-linux_arm.tar.bz2",
-                    "sha256": "e4880d83df3d3f6f4b7b7bcde161e80a0556877468803a3c6066ee4ad18a374c",
+                    "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_arm.tar.bz2",
+                    "sha256": "1888587409b56aef4ba0ab0e6703b3dccba7cc3a022756ba9b908247e5d5a656",
                     "dest": "build/linux"
                 },
                 {
                     "only-arches": ["x86_64"],
                     "type": "file",
-                    "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.1.1-linux_amd64.tar.bz2",
-                    "sha256": "eb5ad0a457dd7f610f7f9b85454399c36755673d61a16f9d07cdfcbbb32ec277",
+                    "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_amd64.tar.bz2",
+                    "sha256": "aa45ee2441ffc3a122daec5802941d1fa2ac47adf5c5c481b5e0daa4dc259ffa",
                     "dest": "build/linux"
                 },
                 {


### PR DESCRIPTION
- Update freedesktop runtime to 19.08
- Update openjdk to openjdk11
- Updated various modules
- Builds only on 64 bits

I need to fix the arm build. It 64bit build is working but throwing console errors. 
TODO reoder modules.