### PR TITLE
Use the version of ant shipped in the OpenJDK extension

### DIFF
--- a/cc.arduino.arduinoide.json
+++ b/cc.arduino.arduinoide.json
@@ -60,12 +60,12 @@
             "buildsystem": "simple",
             "build-options": {
                 "env": {
-                    "PATH": "/usr/bin:/usr/lib/sdk/openjdk11/jvm/openjdk-11/bin",
+                    "PATH": "/usr/bin:/usr/lib/sdk/openjdk11/bin",
                     "JAVA_HOME": "/usr/lib/sdk/openjdk11/jvm/openjdk-11"
                 }
             },
             "build-commands": [
-                "./ant/bin/ant --execdebug build",
+                "ant --execdebug build",
                 "mkdir -p /app/bin /app/Arduino",
                 "cp -a linux/work/* /app/Arduino",
                 "ln -s /app/Arduino/arduino /app/bin",
@@ -348,12 +348,6 @@
                     "url": "http://downloads.arduino.cc/tools/arduinoOTA-1.3.0-linux_amd64.tar.bz2",
                     "sha256": "aa45ee2441ffc3a122daec5802941d1fa2ac47adf5c5c481b5e0daa4dc259ffa",
                     "dest": "build/linux"
-                },
-                {
-                    "type": "archive",
-                    "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.2-bin.tar.xz",
-                    "sha256": "361c8ad2ed8341416e323e7c28af10a8297170a80fdffba294a5c2031527bb6c",
-                    "dest": "build/ant"
                 }
             ]
         }


### PR DESCRIPTION
You may not have realised that the OpenJDK extension also contains Java build tools like Ant, this change switches your application to build using that version of Ant so you don't have to maintain it in your own manifest :-)