### PR TITLE
add libusb-0.1 compat library

### DIFF
--- a/cc.arduino.arduinoide.json
+++ b/cc.arduino.arduinoide.json
@@ -40,6 +40,17 @@
         },
         "shared-modules/libusb/libusb.json",
         {
+            "name": "libusb-compat",
+            "config-opts": [ "--disable-static", "--disable-build-docs" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libusb/libusb-compat-0.1/releases/download/v0.1.7/libusb-compat-0.1.7.tar.gz",
+                    "sha256": "0679ce38aa02498c1eea9c13398a0d2356883d574632a59c1e25274ed4925cf8"
+                }
+            ]
+        },
+        {
             "name": "usbutils",
             "config-opts": [
                 "--datadir=/app/share/hwdata",


### PR DESCRIPTION
fixes #26

Mainly followed [this comment](https://github.com/flathub/cc.arduino.arduinoide/issues/26#issuecomment-1073304747), though I'm not sure, what @hadess meant by the second part (32-bit support). I guess, we'll see, whether the flathub build succeeds with this simple version or if it needs further tweaking.

Anyway, it works for me and I can successfully compile and upload to the Digispark.