### PR TITLE
Update Runtime 22.08

### DIFF
--- a/cc.arduino.arduinoide.json
+++ b/cc.arduino.arduinoide.json
@@ -2,7 +2,7 @@
     "app-id": "cc.arduino.arduinoide",
     "command": "arduino",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.openjdk8"


### PR DESCRIPTION
Small patch to Update Runtime 22.08.

While i haven't created a pr for this it might be worth making a note in the appdata patch that v2 of the IDE was released and advice users that they may want to upgrade/move to that version.