### PR TITLE
Add adafruit-nrfutil to ide to allow working with Adafruit_nRF52 boards.

### DIFF
--- a/cc.arduino.arduinoide.json
+++ b/cc.arduino.arduinoide.json
@@ -353,6 +353,9 @@
                 }
             ]
         },
-        "python3-pyserial.json"
+        "python3-pyserial.json",
+        "python3-click.json",
+        "python3-ecdsa.json",
+        "python3-adafruit-nrfutil.json"
     ]
 }

--- a/python3-adafruit-nrfutil.json
+++ b/python3-adafruit-nrfutil.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-adafruit-nrfutil",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"adafruit-nrfutil\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/18/dc/4fed50ed2192fa5d5b3b2f43c50a629e56fa99198131de6c86a50164a66f/adafruit-nrfutil-0.5.3.post16.tar.gz",
+            "sha256": "b72103dc8e50f92951f512fc2b6f2c621dac1614531ddf8c0be3b13d020e24ad",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "adafruit-nrfutil",
+                "packagetype": "sdist"
+            }
+        }
+    ]
+}

--- a/python3-click.json
+++ b/python3-click.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-click",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"click\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl",
+            "sha256": "bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "click",
+                "packagetype": "bdist_wheel"
+            }
+        }
+    ]
+}

--- a/python3-ecdsa.json
+++ b/python3-ecdsa.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-ecdsa",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"ecdsa\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/09/d4/4f05f5d16a4863b30ba96c23b23e942da8889abfa1cdbabf2a0df12a4532/ecdsa-0.18.0-py2.py3-none-any.whl",
+            "sha256": "80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "ecdsa",
+                "packagetype": "bdist_wheel"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Closes #36.
Includes the binary into the flatpak that is required to use Adafruit_nRF52 boards with the IDE.
Once the board has been installed into the ide through the board manager the IDE will work with these boards now.
